### PR TITLE
Basic module for SAKURA cloud

### DIFF
--- a/sacloud/README.md
+++ b/sacloud/README.md
@@ -1,0 +1,42 @@
+# a dagger module for SAKURA Cloud
+
+## Examples
+
+```cue
+package test
+
+import (
+  "alpha.dagger.io/dagger"
+  "alpha.dagger.io/os"
+  
+  "github.com/sacloud/dagger-modules/sacloud"
+)
+
+account: #AuthStatus
+
+#AuthStatus: {
+	config: sacloud.#Config
+
+	account: string & dagger.#Output
+
+	// Container image
+	ctr: os.#Container & {
+		image: sacloud.#CLI & {
+			"config": config
+		}
+		always: true
+
+		command: """
+			usacloud auth-status -o json > /account
+			"""
+	}
+
+	// account information
+	account: ({
+		os.#File & {
+			from: ctr
+			path: "/account"
+		}
+	}).contents
+}
+```

--- a/sacloud/sacloud.cue
+++ b/sacloud/sacloud.cue
@@ -1,0 +1,16 @@
+// SAKURA cloud base package
+package sacloud
+
+import (
+	"alpha.dagger.io/dagger"
+)
+
+zone: string
+zone: "is1a" | "is1b" | "tk1a" | "tk1b" | "tk1v"
+
+// Config shared by all Sacloud packages
+#Config: {
+	zone: dagger.#Input & {zone}
+	token: dagger.#Input & dagger.#Secret
+	secret: dagger.#Input & dagger.#Secret
+}

--- a/sacloud/usacloud.cue
+++ b/sacloud/usacloud.cue
@@ -1,0 +1,35 @@
+// SAKURA cloud base package
+package sacloud
+
+import (
+	"alpha.dagger.io/docker"
+	"alpha.dagger.io/os"
+)
+
+// Default image and version
+let defaultVersion = "latest"
+
+// Re-usable cli(usacloud) component
+#CLI: {
+	config: #Config
+
+	version: string | *defaultVersion
+
+	// Container image
+	os.#Container & {
+		image: docker.#Pull & {
+			from: "ghcr.io/sacloud/usacloud:\(version)"
+		}
+
+		always: true
+
+		command: """
+			usacloud config edit --token "$(cat /run/secrets/token)" --secret "$(cat /run/secrets/secret)" --zone "\(config.zone)" --default-output-type table > /dev/null 2>&1
+			"""
+
+		secret: {
+		  "/run/secrets/token":  config.token
+		  "/run/secrets/secret": config.secret
+		}
+	}
+}


### PR DESCRIPTION
dagger/daggerでUsacloudを用いるためのcueモジュールの例

例: 現在のAPIユーザーの情報をoutputとする例

```cue
package test

import (
  "alpha.dagger.io/dagger"
  "alpha.dagger.io/os"
  "github.com/sacloud/dagger-modules/sacloud"
)

#AuthStatus: {
	config: sacloud.#Config

	account: string & dagger.#Output

	// Container image
	ctr: os.#Container & {
		image: sacloud.#CLI & {
			"config": config
		}
		always: true

		command: """
			usacloud auth-status -o json > /account
			"""
	}

	// account information
	account: ({
		os.#File & {
			from: ctr
			path: "/account"
		}
	}).contents
}

account: #AuthStatus
```